### PR TITLE
Newly created pools with low liquidity are filtered from the pool list, at least for a while #59

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -212,8 +212,7 @@ async function getPoolsNoPaging(payload, isCurrentNetwork?) {
     pools: {
       __args: {
         where: {
-          finalized: true,
-          liquidity_gt: 0
+          finalized: true
         },
         orderBy,
         orderDirection


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Pools with low liquidity are now displayed as sometimes liquidity might be in 0.00001 etc
- 
- 
