### PR TITLE
Added bonus rewards check for SYMM Optics v2

### DIFF
--- a/src/helpers/miningFactors.ts
+++ b/src/helpers/miningFactors.ts
@@ -25,7 +25,7 @@ export function getStakingBoostOfPair(
   poolId: string
 ) {
   if (
-    token1 == BAL_TOKEN[chainId].toLowerCase() &&
+    (token1 == BAL_TOKEN[chainId].toLowerCase() || "0x8427bD503dd3169cCC9aFF7326c15258Bc305478".toLowerCase()) &&
     uncappedTokens[chainId].includes(token2)
   ) {
     return balMultiplier
@@ -33,7 +33,7 @@ export function getStakingBoostOfPair(
       .plus(weight2)
       .div(weight1.plus(weight2));
   } else if (
-    token2 == BAL_TOKEN[chainId].toLowerCase() &&
+    (token2 == BAL_TOKEN[chainId].toLowerCase() || "0x8427bD503dd3169cCC9aFF7326c15258Bc305478".toLowerCase()) &&
     uncappedTokens[chainId].includes(token1)
   ) {
     return weight1


### PR DESCRIPTION
There's now a second SYMM token on Celo resulting from the Optics v2 bridge and so for rewards we also need to check for this token address when identifying bonus rewards.
This is hard coded since there should be no risk of collision. 