### PR TITLE
corrected pool that GNO rewards applied to and fixed SYMM rewards bon…

### DIFF
--- a/src/helpers/miningFactors.ts
+++ b/src/helpers/miningFactors.ts
@@ -25,7 +25,7 @@ export function getStakingBoostOfPair(
   poolId: string
 ) {
   if (
-    (token1 == BAL_TOKEN[chainId].toLowerCase() || "0x8427bD503dd3169cCC9aFF7326c15258Bc305478".toLowerCase()) &&
+    (token1 == BAL_TOKEN[chainId].toLowerCase() || token1 == "0x8427bD503dd3169cCC9aFF7326c15258Bc305478".toLowerCase()) &&
     uncappedTokens[chainId].includes(token2)
   ) {
     return balMultiplier
@@ -33,7 +33,7 @@ export function getStakingBoostOfPair(
       .plus(weight2)
       .div(weight1.plus(weight2));
   } else if (
-    (token2 == BAL_TOKEN[chainId].toLowerCase() || "0x8427bD503dd3169cCC9aFF7326c15258Bc305478".toLowerCase()) &&
+    (token2 == BAL_TOKEN[chainId].toLowerCase() || token2 == "0x8427bD503dd3169cCC9aFF7326c15258Bc305478".toLowerCase()) &&
     uncappedTokens[chainId].includes(token1)
   ) {
     return weight1

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -533,27 +533,27 @@ export async function formatPool(pool) {
   // GNO(Gnosis) APR and rewards
   // $100k for 168 days = $16666 per month (28 days) = $595.21 per day
   const enum gnoPool {
-    GNO_AGVE,
     GNO_WXDAI,
     SYMM_WXDAI,
+    STAKE_AGVE,
     None
   }
   let gnoPoolIndex = gnoPool.None;
 
-  if (findPoolFromTokens(crPool, 'GNO', 'AGVE', 60, 40)) {
-    gnoPoolIndex = gnoPool.GNO_AGVE;
-  } else if (findPoolFromTokens(crPool, 'GNO', 'WXDAI', 60, 40)) {
+  if (findPoolFromTokens(crPool, 'GNO', 'WXDAI', 60, 40)) {
     gnoPoolIndex = gnoPool.GNO_WXDAI;
   } else if (findPoolFromTokens(crPool, 'SYMM', 'WXDAI', 60, 40)) {
     gnoPoolIndex = gnoPool.SYMM_WXDAI;
+  } else if (findPoolFromTokens(crPool, 'STAKE', 'AGVE', 60, 40)) {
+    gnoPoolIndex = gnoPool.STAKE_AGVE;
   }
 
   if (gnoPoolIndex !== gnoPool.None) {
     const GNOprice = store.getters['getGNOprice'];
     const gnoDailyCoinReward = [
-      new BigNumber((595.21 * 0.2) / Number(GNOprice)),
       new BigNumber((595.21 * 0.3) / Number(GNOprice)),
-      new BigNumber((595.21 * 0.5) / Number(GNOprice))
+      new BigNumber((595.21 * 0.5) / Number(GNOprice)),
+      new BigNumber((595.21 * 0.2) / Number(GNOprice))
     ];
     crPool.tokenRewardGno = gnoDailyCoinReward[gnoPoolIndex];
 


### PR DESCRIPTION
Two issues that were addressed in the previous build are as follows.

1. GNO rewards are applied to the original STAKE pool, not new GNO pool. This has been corrected. In the future we will need to apply rewards to the new GNO pool.
2. A bug that meant when checking for SYMM v2 bonus it would test true for every pool.