### PR TITLE
Issue 110 apr message

### DIFF
--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -50,10 +50,7 @@
 
     <div class="cards">
       <div class="cardInfo rounded-1">
-        <div
-          class="highlight-card anim-fade-in rounded-1 d-flex tooltipped tooltipped-n tooltippedBottom"
-          :aria-label="APR_FORMULA"
-        >
+        <div class="highlight-card anim-fade-in rounded-1 d-flex">
           <div>
             <span>
               <span class="span-text-key">TVL Celo: </span>
@@ -162,6 +159,12 @@
           </span> -->
             &nbsp;
             <span class="span-text-value">*Last trade price )</span>
+            <span
+              class="tooltipped tooltipped-e m-2 tooltipped-multiline"
+              :aria-label="APR_FORMULA"
+            >
+              <Icon name="info" size="16" />
+            </span>
           </div>
         </div>
       </div>
@@ -520,6 +523,9 @@ export default {
       }
     }
   }
+}
+.tooltipped {
+  cursor: pointer;
 }
 @media (max-width: 543px) {
   .filter-by-asset {

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -50,7 +50,10 @@
 
     <div class="cards">
       <div class="cardInfo rounded-1">
-        <div class="highlight-card anim-fade-in rounded-1 d-flex">
+        <div
+          class="highlight-card anim-fade-in rounded-1 d-flex tooltipped tooltipped-n tooltippedBottom"
+          aria-label="[(current token price) * (Daily reward token quantity) / (Total Value Locked)] * 365 days * 100"
+        >
           <div>
             <span>
               <span class="span-text-key">TVL Celo: </span>

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -52,7 +52,7 @@
       <div class="cardInfo rounded-1">
         <div
           class="highlight-card anim-fade-in rounded-1 d-flex tooltipped tooltipped-n tooltippedBottom"
-          aria-label="[(current token price) * (Daily reward token quantity) / (Total Value Locked)] * 365 days * 100"
+          :aria-label="APR_FORMULA"
         >
           <div>
             <span>
@@ -213,6 +213,7 @@ import {
 } from '@/helpers/utils';
 // import LineChart from './LineChart';
 import BigNumber from '@/helpers/bignumber';
+import { APR_FORMULA } from '@/helpers/constants';
 // import { mapState } from 'vuex';
 
 export default {
@@ -244,7 +245,8 @@ export default {
         private: 'Private'
       },
       modalOpen: false,
-      totalPoolValues: {}
+      totalPoolValues: {},
+      APR_FORMULA
     };
   },
   async mounted() {

--- a/src/components/List/Pools.vue
+++ b/src/components/List/Pools.vue
@@ -84,11 +84,14 @@
                     <span v-text="$t('apy')" class="text-white-normal" />:
                     <UiNum :value="item.apy" format="percent" class="column" />
                   </div>
-                  <div
-                    class="grouptext margin-top10 tooltipped tooltipped-n"
-                    :aria-label="APR_FORMULA"
-                  >
+                  <div class="grouptext margin-top10">
                     <span v-text="$t('rewardApy')" class="text-white-normal" />
+                    <span
+                      class="tooltipped tooltipped-e m-1 tooltipped-multiline"
+                      :aria-label="APR_FORMULA"
+                    >
+                      <Icon name="info" size="16" />
+                    </span>
                     <UiNum :value="item.rewardApy" format="percent" /> SYMM
                     <span v-if="item.rewardApyCelo">
                       /
@@ -320,11 +323,16 @@
           />
         </div>
         <div
-          class="table-column hide-sm hide-md table-sort tooltipped tooltipped-n"
+          class="table-column hide-sm hide-md table-sort"
           @click="handleSort('rewardApy')"
-          :aria-label="APR_FORMULA"
         >
           {{ $t('rewardApy') }}
+          <span
+            class="tooltipped tooltipped-e m-2 tooltipped-multiline"
+            :aria-label="APR_FORMULA"
+          >
+            <Icon name="info" size="16" />
+          </span>
           <img
             v-if="sortDirection === 'DESC' && sortField === 'rewardApy'"
             src="@/assets/arrow-up.svg"

--- a/src/components/List/Pools.vue
+++ b/src/components/List/Pools.vue
@@ -84,8 +84,11 @@
                     <span v-text="$t('apy')" class="text-white-normal" />:
                     <UiNum :value="item.apy" format="percent" class="column" />
                   </div>
-                  <div class="grouptext margin-top10">
-                    <span v-text="$t('rewardApy')" class="text-white-normal" />:
+                  <div
+                    class="grouptext margin-top10 tooltipped tooltipped-n"
+                    :aria-label="APR_FORMULA"
+                  >
+                    <span v-text="$t('rewardApy')" class="text-white-normal" />
                     <UiNum :value="item.rewardApy" format="percent" /> SYMM
                     <span v-if="item.rewardApyCelo">
                       /
@@ -317,8 +320,9 @@
           />
         </div>
         <div
-          class="table-column hide-sm hide-md table-sort"
+          class="table-column hide-sm hide-md table-sort tooltipped tooltipped-n"
           @click="handleSort('rewardApy')"
+          :aria-label="APR_FORMULA"
         >
           {{ $t('rewardApy') }}
           <img
@@ -440,7 +444,7 @@ import { formatFilters, ITEMS_PER_PAGE } from '@/helpers/utils';
 // import { getPoolLiquidity } from '@/helpers/price';
 import { SYMM_TOKENS } from '@/helpers/tokens';
 import config from '@/config';
-import { crPoolIds } from '@/helpers/constants';
+import { crPoolIds, APR_FORMULA } from '@/helpers/constants';
 import BigNumber from '@/helpers/bignumber';
 
 export default {
@@ -458,7 +462,8 @@ export default {
       currentTotalPoolValues: {},
       totalPoolValues: {},
       sortDirection: 'DESC',
-      sortField: ''
+      sortField: '',
+      APR_FORMULA
     };
   },
   mounted() {
@@ -645,7 +650,7 @@ export default {
     .highlight-card {
       height: 100%;
       border: solid 1px var(--card-border-color);
-      overflow: hidden;
+
 
       &:hover {
         background-color: var(--card-hover-background);

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -15,3 +15,6 @@ export const specificPools = {
   symmV1CELO: '0xf3ce35b10d3c9e74b0e6084ce08fd576fd9ec221',
   symmV2CELO: '0x7ee06450f4ff97990c6288237964bf4f545f221f'
 };
+
+export const APR_FORMULA =
+  'APR Formula: [(current token price) * (Daily reward token quantity) / (Total Value Locked)] * 365 days * 100';

--- a/src/style.scss
+++ b/src/style.scss
@@ -275,6 +275,28 @@ input {
   }
 }
 
+.tooltippedBottom {
+  &::before {
+    border-top-color: $input-hover-border !important;
+    margin-bottom: 14px;
+    top: 30px !important;
+  }
+
+  &::after {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    // max-width: 320px;
+    top: 37px;
+    height: 25px;
+    margin-bottom: 14px;
+    border-radius: 20px;
+    padding: 4px 16px;
+    font-size: 14px;
+    background-color: $input-hover-border;
+    color: var(--text-primary-color);
+  }
+}
+
 .shake-horizontal {
   -webkit-animation: shake-horizontal 0.8s
     cubic-bezier(0.455, 0.03, 0.515, 0.955) both;

--- a/src/style.scss
+++ b/src/style.scss
@@ -255,7 +255,7 @@ input {
   color: $warning;
 }
 
-.tooltipped {
+.tooltipped-n {
   &::before {
     border-top-color: $input-hover-border !important;
     margin-bottom: 14px;
@@ -275,20 +275,12 @@ input {
   }
 }
 
-.tooltippedBottom {
+.tooltipped-e {
   &::before {
-    border-top-color: $input-hover-border !important;
-    margin-bottom: 14px;
-    top: 30px !important;
+    border-right-color: $input-hover-border !important;
   }
 
   &::after {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    // max-width: 320px;
-    top: 35px;
-    height: 25px;
-    margin-bottom: 14px;
     border-radius: 20px;
     padding: 4px 16px;
     font-size: 14px;

--- a/src/style.scss
+++ b/src/style.scss
@@ -286,7 +286,7 @@ input {
     overflow: hidden;
     text-overflow: ellipsis;
     // max-width: 320px;
-    top: 37px;
+    top: 35px;
     height: 25px;
     margin-bottom: 14px;
     border-radius: 20px;


### PR DESCRIPTION
Fixes #110 .

Changes proposed in this pull request:
- Add an icon to the top of the pools UI page, which explains how the APR is derived. When hovering the icon, it will pop up the message.
- Add icon next to the "Reward APR" in the card
- Add icon next to the "Reward APR" column in the pools UI table header
